### PR TITLE
Implement core pipeline steps and utilities

### DIFF
--- a/src/core/contracts.py
+++ b/src/core/contracts.py
@@ -1,1 +1,28 @@
-# Placeholder for contracts definitions
+"""Simple data structures used by the plugins.
+
+The production project uses more feature rich implementations but for the unit
+tests we only need light–weight containers describing the inputs/outputs for a
+step and the result of executing a step.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Any, Optional
+
+
+@dataclass
+class StepIO:
+    """Container describing paths used by a step."""
+
+    inputs: Dict[str, str]
+    outputs: Dict[str, str]
+
+
+@dataclass
+class ValidationResult:
+    """Represents the outcome of running a step."""
+
+    success: bool
+    messages: List[str]
+    metrics: Optional[Dict[str, Any]] = None

--- a/src/core/io_utils.py
+++ b/src/core/io_utils.py
@@ -1,1 +1,55 @@
-# Placeholder for IO utilities
+"""Utility helpers for reading and writing simple spreadsheet like files.
+
+The real project uses Excel and pandas, but those heavy dependencies are
+unavailable in the execution environment for the kata.  These helpers implement
+just enough functionality for the unit tests by storing tabular data as CSV
+files.  The helpers intentionally keep the API surface small so that plugins can
+rely on them in the same way the real project would rely on more capable
+libraries.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Dict, Any, Sequence
+import csv
+import hashlib
+
+
+def expand(template: str, **values: Any) -> str:
+    """Expand placeholders in ``template`` using ``str.format`` semantics."""
+    return template.format(**values)
+
+
+def read_excel(path: str) -> list[Dict[str, Any]]:
+    """Read a pseudo Excel file returning a list of string valued rows."""
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        return [dict(row) for row in reader]
+
+
+def write_excel(rows: Iterable[Dict[str, Any]], path: str, headers: Sequence[str] | None = None) -> None:
+    """Write rows to a pseudo Excel file.
+
+    ``rows`` is an iterable of dictionaries.  ``headers`` can be provided to
+    explicitly control column order; when omitted it is derived from the first
+    row.  The destination directory is created automatically.
+    """
+    path_obj = Path(path)
+    path_obj.parent.mkdir(parents=True, exist_ok=True)
+    rows = list(rows)
+    if headers is None:
+        headers = list(rows[0].keys()) if rows else []
+    with path_obj.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=list(headers))
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def file_hash(path: str) -> str:
+    """Return a SHA256 hash of the file at ``path``."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        h.update(f.read())
+    return h.hexdigest()

--- a/src/core/registry.py
+++ b/src/core/registry.py
@@ -1,1 +1,19 @@
-# Placeholder for registry utilities
+"""Minimal registry used to associate step names with their classes."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Type
+
+_REGISTRY: Dict[str, Type] = {}
+
+
+def register(name: str) -> Callable[[Type], Type]:
+    """Class decorator registering a step implementation."""
+    def decorator(cls: Type) -> Type:
+        _REGISTRY[name] = cls
+        return cls
+    return decorator
+
+
+def get(name: str) -> Type:
+    return _REGISTRY[name]

--- a/src/core/step_base.py
+++ b/src/core/step_base.py
@@ -1,1 +1,28 @@
-# Placeholder for step base implementation
+"""Base class for steps in the demo pipeline."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class Step:
+    """Minimal step implementation.
+
+    Real project steps inherit from a richer base class.  The simplified version
+    merely stores configuration and context information so that unit tests can
+    exercise the plugin logic.
+    """
+
+    name = "Step"
+
+    def __init__(self, cfg: Dict[str, Any], folders: Dict[str, str], naming: Dict[str, str], period: str) -> None:
+        self.cfg = cfg
+        self.folders = folders
+        self.naming = naming
+        self.period = period
+
+    def plan_io(self):
+        raise NotImplementedError
+
+    def run(self, io):
+        raise NotImplementedError

--- a/src/core/validation_utils.py
+++ b/src/core/validation_utils.py
@@ -1,1 +1,27 @@
-# Placeholder for validation utilities
+"""Validation helpers used by the simplified plugins."""
+
+from __future__ import annotations
+
+from typing import Iterable, Dict, Sequence
+
+
+def require_columns(rows: Iterable[Dict[str, object]], required: Sequence[str]) -> list[str]:
+    """Return a list of required columns that are missing from ``rows``."""
+    rows = list(rows)
+    if not rows:
+        return list(required)
+    cols = set(rows[0].keys())
+    return [c for c in required if c not in cols]
+
+
+def debits_equal_credits(rows: Iterable[Dict[str, object]]) -> bool:
+    """Verify that total debits equal total credits."""
+    debit = 0.0
+    credit = 0.0
+    for row in rows:
+        try:
+            debit += float(row.get("Debit", 0) or 0)
+            credit += float(row.get("Credit", 0) or 0)
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            return False
+    return abs(debit - credit) < 1e-6

--- a/src/plugins/fx_translator.py
+++ b/src/plugins/fx_translator.py
@@ -1,1 +1,81 @@
-# Step 4: FX translator placeholder
+"""Implementation of the ``FXTranslator`` step.
+
+This step enriches the master trial balance with foreign exchange rates and
+produces both an adjusted TB and a separate FX adjustment file.  The
+implementation is intentionally lightweight and operates on CSV based pseudo
+Excel files to keep the test environment small.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from core.registry import register
+from core.step_base import Step
+from core.contracts import StepIO, ValidationResult
+from core.io_utils import expand, read_excel, write_excel
+
+
+@register("FXTranslator")
+class FXTranslator(Step):
+    name = "FXTranslator"
+
+    def plan_io(self) -> StepIO:
+        tb_dir = self.folders["tb"]
+        fx_dir = self.folders["fx"]
+        master_in = f"{tb_dir}/" + expand(self.naming["master_tb"], period=self.period)
+        fx_rates = expand(self.naming["fx_rates"], period=self.period)
+        fx_adj = f"{fx_dir}/" + expand(self.naming["fx_adjustments"], period=self.period)
+        master_out = f"{tb_dir}/Master_TB_{self.period}_Adjusted.xlsx"
+        return StepIO(
+            inputs={"master_tb": master_in, "fx_rates": f"{fx_dir}/{fx_rates}"},
+            outputs={"adjusted_tb": master_out, "fx_adjustments": fx_adj},
+        )
+
+    def _load_rates(self, fx_source: str, rates_file: str, reporting_currency: str) -> Dict[str, float]:
+        """Load FX rates from a file.  External sources are intentionally unsupported."""
+        if fx_source != "file":  # pragma: no cover - defensive
+            raise ValueError("Only file FX sources are supported in the test implementation")
+        rows = read_excel(rates_file)
+        return {row["CurrencyCode"]: float(row["FXRate"]) for row in rows}
+
+    def run(self, io: StepIO) -> ValidationResult:
+        params = self.cfg["params"]
+        tol = params.get("tolerance", 5)
+        reporting = self.cfg.get("reporting_currency", "USD")
+
+        tb = read_excel(io.inputs["master_tb"])
+        rates = self._load_rates(params.get("fx_source", "file"), io.inputs["fx_rates"], reporting)
+
+        if tb and "CurrencyCode" not in tb[0]:
+            return ValidationResult(False, ["Missing CurrencyCode in TB"])
+
+        missing_codes: List[str] = []
+        for row in tb:
+            code = row.get("CurrencyCode")
+            rate = rates.get(code)
+            if rate is None:
+                missing_codes.append(code)
+                continue
+            row["FXRate"] = rate
+            row["LocalAmount"] = float(row.get("Debit", 0) or 0) - float(row.get("Credit", 0) or 0)
+            row["ReportingCurrencyAmount"] = round(row["LocalAmount"] * rate, 2)
+
+        if missing_codes:
+            return ValidationResult(False, [f"Missing FX rates for: {sorted(set(missing_codes))}"])
+
+        fx_adj = [
+            {
+                "EntityCode": r.get("EntityCode"),
+                "AccountCode": r.get("AccountCode"),
+                "LocalAmount": r["LocalAmount"],
+                "FXRate": r["FXRate"],
+                "ReportingCurrencyAmount": r["ReportingCurrencyAmount"],
+                "Period": self.period,
+            }
+            for r in tb
+        ]
+
+        write_excel(tb, io.outputs["adjusted_tb"])
+        write_excel(fx_adj, io.outputs["fx_adjustments"])
+        return ValidationResult(True, [f"Applied FX to {len(tb)} rows"], {"rows": len(tb), "tolerance": tol})

--- a/src/plugins/pdf_assembler.py
+++ b/src/plugins/pdf_assembler.py
@@ -1,1 +1,52 @@
-# Step 7: PDF assembler placeholder
+"""Implementation of the ``PDFAssembler`` step.
+
+The original project produced rich PDF reports.  To keep this kata light‑weight
+we simulate the behaviour by converting tabular data into plain text files with a
+``.pdf`` extension and concatenating them.  This is sufficient for unit tests to
+exercise the control flow of the step.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from core.registry import register
+from core.step_base import Step
+from core.contracts import StepIO, ValidationResult
+from core.io_utils import expand, read_excel
+
+
+def excel_to_simple_pdf(excel_path: str, pdf_path: str) -> None:
+    """Create a rudimentary PDF (actually a text file) from tabular data."""
+    rows = read_excel(excel_path)
+    with open(pdf_path, "w") as f:
+        for row in rows[:1000]:
+            f.write(" | ".join(str(v) for v in row.values()))
+            f.write("\n")
+
+
+@register("PDFAssembler")
+class PDFAssembler(Step):
+    name = "PDFAssembler"
+
+    def plan_io(self) -> StepIO:
+        support_pdf = f"{self.folders['support']}/" + expand(self.naming["support_pdf"], period=self.period)
+        return StepIO(inputs={}, outputs={"support": support_pdf})
+
+    def run(self, io: StepIO) -> ValidationResult:
+        inc: List[str] = self.cfg["params"]["include"]
+        pdfs: List[str] = []
+        for p in inc:
+            path = expand(p, tb=self.folders["tb"], fx=self.folders["fx"], period=self.period)
+            pdf_out = Path(path).with_suffix(".pdf").as_posix()
+            excel_to_simple_pdf(path, pdf_out)
+            pdfs.append(pdf_out)
+
+        Path(io.outputs["support"]).parent.mkdir(parents=True, exist_ok=True)
+        with open(io.outputs["support"], "w") as out_f:
+            for p in pdfs:
+                with open(p) as f:
+                    out_f.write(f.read())
+                    out_f.write("\n")
+        return ValidationResult(True, [f"Merged {len(pdfs)} PDFs → {io.outputs['support']}"] , {"source_pdfs": len(pdfs)})

--- a/src/plugins/tb_collector.py
+++ b/src/plugins/tb_collector.py
@@ -1,1 +1,54 @@
-# Step 2: TB collector placeholder
+"""Implementation of the ``TBCollector`` step.
+
+The real project loads a number of trial balance (TB) spreadsheets and merges
+them into a master TB.  The simplified implementation operates on small CSV
+files with an ``.xlsx`` extension so that the tests can run without heavy
+third‑party dependencies.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Dict
+
+from core.registry import register
+from core.step_base import Step
+from core.contracts import StepIO, ValidationResult
+from core.io_utils import expand, read_excel, write_excel
+from core.validation_utils import require_columns, debits_equal_credits
+
+
+@register("TBCollector")
+class TBCollector(Step):
+    name = "TBCollector"
+
+    def plan_io(self) -> StepIO:
+        tb_dir = self.folders["tb"]
+        out_master = expand(self.naming["master_tb"], period=self.period)
+        return StepIO(inputs={"tb_folder": tb_dir},
+                      outputs={"master_tb": f"{tb_dir}/{out_master}"})
+
+    def run(self, io: StepIO) -> ValidationResult:
+        req_cols: List[str] = self.cfg["params"]["required_columns"]
+        enforce_balanced = self.cfg["params"].get("enforce_balanced", True)
+
+        rows: List[Dict[str, object]] = []
+        metrics = {"files": 0, "rows": 0}
+        messages: List[str] = []
+        for path in Path(io.inputs["tb_folder"]).glob(f"TB_*_{self.period}.xlsx"):
+            data = read_excel(path)
+            missing = require_columns(data, req_cols)
+            if missing:
+                messages.append(f"{path.name}: missing {missing}")
+                return ValidationResult(False, messages)
+            if enforce_balanced and not debits_equal_credits(data):
+                messages.append(f"{path.name}: debits != credits")
+                return ValidationResult(False, messages)
+            rows.extend(data)
+            metrics["files"] += 1
+            metrics["rows"] += len(data)
+
+        # Always produce a file with the proper header even if no TBs were found
+        write_excel(rows, io.outputs["master_tb"], headers=req_cols)
+        messages.append(f"Master TB rows={len(rows)} files={metrics['files']}")
+        return ValidationResult(True, messages, metrics)

--- a/tests/test_fx_translator.py
+++ b/tests/test_fx_translator.py
@@ -1,5 +1,39 @@
-import pytest
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from core.io_utils import write_excel, read_excel
+from plugins.fx_translator import FXTranslator
 
 
-def test_placeholder():
-    assert True
+def test_applies_fx_rates(tmp_path):
+    tb_dir = tmp_path / "tb"
+    fx_dir = tmp_path / "fx"
+    tb_dir.mkdir(); fx_dir.mkdir()
+
+    master = [
+        {"EntityCode": "E1", "AccountCode": "A1", "Debit": 100, "Credit": 0, "CurrencyCode": "USD"},
+        {"EntityCode": "E2", "AccountCode": "A1", "Debit": 0, "Credit": 200, "CurrencyCode": "EUR"},
+    ]
+    rates = [
+        {"CurrencyCode": "USD", "FXRate": 1},
+        {"CurrencyCode": "EUR", "FXRate": 1.1},
+    ]
+    write_excel(master, tb_dir / "Master_TB_202301.xlsx")
+    write_excel(rates, fx_dir / "Rates_202301.xlsx")
+
+    cfg = {"params": {"fx_source": "file"}, "reporting_currency": "USD"}
+    folders = {"tb": tb_dir.as_posix(), "fx": fx_dir.as_posix()}
+    naming = {"master_tb": "Master_TB_{period}.xlsx", "fx_rates": "Rates_{period}.xlsx", "fx_adjustments": "FXAdj_{period}.xlsx"}
+    step = FXTranslator(cfg, folders, naming, period="202301")
+
+    io = step.plan_io()
+    result = step.run(io)
+
+    assert result.success
+    adjusted = read_excel(io.outputs["adjusted_tb"])
+    assert float(adjusted[1]["FXRate"]) == 1.1
+    assert float(adjusted[1]["ReportingCurrencyAmount"]) == round((0 - 200) * 1.1, 2)
+    fx_adj = read_excel(io.outputs["fx_adjustments"])
+    assert fx_adj[0]["Period"] == "202301"

--- a/tests/test_pdf_assembler.py
+++ b/tests/test_pdf_assembler.py
@@ -1,5 +1,35 @@
-import pytest
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from core.io_utils import write_excel
+from plugins.pdf_assembler import PDFAssembler
 
 
-def test_placeholder():
-    assert True
+def test_merges_generated_pdfs(tmp_path):
+    tb_dir = tmp_path / "tb"
+    fx_dir = tmp_path / "fx"
+    support_dir = tmp_path / "support"
+    tb_dir.mkdir(); fx_dir.mkdir(); support_dir.mkdir()
+
+    write_excel([
+        {"a": 1, "b": 2}
+    ], tb_dir / "file1_202301.xlsx")
+    write_excel([
+        {"a": 3, "b": 4}
+    ], fx_dir / "file2_202301.xlsx")
+
+    cfg = {"params": {"include": ["{tb}/file1_{period}.xlsx", "{fx}/file2_{period}.xlsx"]}}
+    folders = {"tb": tb_dir.as_posix(), "fx": fx_dir.as_posix(), "support": support_dir.as_posix()}
+    naming = {"support_pdf": "Support_{period}.pdf"}
+    step = PDFAssembler(cfg, folders, naming, period="202301")
+
+    io = step.plan_io()
+    result = step.run(io)
+
+    assert result.success
+    out_path = Path(io.outputs["support"])
+    assert out_path.exists()
+    content = out_path.read_text().strip()
+    assert "1 | 2" in content and "3 | 4" in content

--- a/tests/test_tb_collector.py
+++ b/tests/test_tb_collector.py
@@ -1,5 +1,38 @@
-import pytest
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from core.io_utils import write_excel, read_excel
+from plugins.tb_collector import TBCollector
 
 
-def test_placeholder():
-    assert True
+def test_collects_and_merges_trial_balances(tmp_path):
+    tb_dir = tmp_path / "tb"
+    tb_dir.mkdir()
+
+    tb1 = [
+        {"EntityCode": "E1", "AccountCode": "A1", "Debit": 100, "Credit": 0},
+        {"EntityCode": "E1", "AccountCode": "A2", "Debit": 0, "Credit": 100},
+    ]
+    tb2 = [
+        {"EntityCode": "E2", "AccountCode": "A1", "Debit": 50, "Credit": 0},
+        {"EntityCode": "E2", "AccountCode": "A2", "Debit": 0, "Credit": 50},
+    ]
+    write_excel(tb1, tb_dir / "TB_E1_202301.xlsx")
+    write_excel(tb2, tb_dir / "TB_E2_202301.xlsx")
+
+    cfg = {"params": {"required_columns": ["EntityCode", "AccountCode", "Debit", "Credit"]}}
+    folders = {"tb": tb_dir.as_posix()}
+    naming = {"master_tb": "Master_TB_{period}.xlsx"}
+    step = TBCollector(cfg, folders, naming, period="202301")
+
+    io = step.plan_io()
+    result = step.run(io)
+
+    assert result.success
+    master_path = Path(io.outputs["master_tb"])
+    assert master_path.exists()
+    rows = read_excel(master_path)
+    assert len(rows) == 4
+    assert result.metrics == {"files": 2, "rows": 4}


### PR DESCRIPTION
## Summary
- implement TBCollector to merge trial balance files with validations
- add FXTranslator for applying FX rates and producing adjustment outputs
- create PDFAssembler to convert spreadsheets to text-based PDFs and merge them
- provide lightweight core infrastructure and CSV-based I/O helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a3fca7afec832ca559c7d7eb6be76e