### PR TITLE
Handle dataframe inputs and relax CSV writing

### DIFF
--- a/src/core/io_utils.py
+++ b/src/core/io_utils.py
@@ -99,7 +99,7 @@ def write_excel(
         rows = list(obj)
     cols = list(headers) if headers else (list(rows[0].keys()) if rows else [])
     with p.open("w", newline="") as f:
-        w = csv.DictWriter(f, fieldnames=cols)
+        w = csv.DictWriter(f, fieldnames=cols, extrasaction="ignore")
         w.writeheader()
         for r in rows:
             w.writerow(r)

--- a/src/plugins/fx_translator.py
+++ b/src/plugins/fx_translator.py
@@ -37,6 +37,8 @@ class FXTranslator(Step):
         if fx_source != "file":  # pragma: no cover - defensive
             raise ValueError("Only file FX sources are supported in the test implementation")
         rows = read_excel(rates_file)
+        if not isinstance(rows, list):
+            rows = rows.to_dict(orient="records")
         return {row["CurrencyCode"]: float(row["FXRate"]) for row in rows}
 
     def run(self, io: StepIO) -> ValidationResult:
@@ -45,6 +47,8 @@ class FXTranslator(Step):
         reporting = self.cfg.get("reporting_currency", "USD")
 
         tb = read_excel(io.inputs["master_tb"])
+        if not isinstance(tb, list):
+            tb = tb.to_dict(orient="records")
         rates = self._load_rates(params.get("fx_source", "file"), io.inputs["fx_rates"], reporting)
 
         if tb and "CurrencyCode" not in tb[0]:

--- a/src/plugins/pdf_assembler.py
+++ b/src/plugins/pdf_assembler.py
@@ -20,6 +20,8 @@ from core.io_utils import expand, read_excel
 def excel_to_simple_pdf(excel_path: str, pdf_path: str) -> None:
     """Create a rudimentary PDF (actually a text file) from tabular data."""
     rows = read_excel(excel_path)
+    if not isinstance(rows, list):
+        rows = rows.to_dict(orient="records")
     with open(pdf_path, "w") as f:
         for row in rows[:1000]:
             f.write(" | ".join(str(v) for v in row.values()))


### PR DESCRIPTION
- Ignore extra keys when writing CSV fallback, preventing ValueErrors
- Accept pandas DataFrames in FXTranslator and PDF assembler helpers
- Support pipelines regardless of pandas availability