### PR TITLE
Add tutorial catalog generation

### DIFF
--- a/notebooks/Client_Engagement_Letter_Draft_Tutorial.ipynb
+++ b/notebooks/Client_Engagement_Letter_Draft_Tutorial.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "473a6ff0",
+   "id": "3085bf72",
    "metadata": {},
    "source": [
     "# Client Engagement Letter Draft — Hands-on Tutorial\n",
@@ -12,7 +12,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef1cb5bb",
+   "id": "c0b16e72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd0de515",
+   "id": "c705221d",
    "metadata": {},
    "source": [
     "## 1. Simulate practice management API calls\n",
@@ -44,7 +44,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "339fdf40",
+   "id": "d3b8ec29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ef86c93",
+   "id": "d921546e",
    "metadata": {},
    "source": [
     "## 2. Create sample engagement data\n",
@@ -206,7 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7a06563a",
+   "id": "1403ac01",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +244,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9f7c4ae",
+   "id": "af7b8758",
    "metadata": {},
    "source": [
     "## 3. Review the staged inputs\n",
@@ -254,7 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "da0b2d6c",
+   "id": "801701ad",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -270,7 +270,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34c99e8e",
+   "id": "f8cd403c",
    "metadata": {},
    "source": [
     "## 4. Configure and run the step\n",
@@ -280,7 +280,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6b2d8821",
+   "id": "53e9bd58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -311,7 +311,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f9e8968",
+   "id": "fcdc4199",
    "metadata": {},
    "source": [
     "## 5. Inspect generated artifacts\n",
@@ -321,7 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b86d574f",
+   "id": "163b3e78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -342,7 +342,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e923c0bc",
+   "id": "89d80681",
    "metadata": {},
    "source": [
     "## 6. Next steps\n",

--- a/notebooks/client_engagement_letter_draft_example.py
+++ b/notebooks/client_engagement_letter_draft_example.py
@@ -4,6 +4,14 @@ from __future__ import annotations
 
 from pathlib import Path
 import json
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from amplify_automations.core.tutorial_catalog import register_tutorial
 
 try:
     import nbformat as nbf
@@ -340,6 +348,21 @@ def build_notebook() -> None:
     out_path = ROOT / "Client_Engagement_Letter_Draft_Tutorial.ipynb"
     with out_path.open("w", encoding="utf-8") as fh:
         nbf.write(nb, fh)
+
+    register_tutorial(
+        step_name="ClientEngagementLetterDraft",
+        description=(
+            "Generate draft client engagement letters from CRM metadata, service "
+            "catalogues, and reusable templates."
+        ),
+        tutorial_path=f"notebooks/{out_path.name}",
+        tools=[
+            "Deltek Vantagepoint mock API integration",
+            "Practice CS mock API integration",
+            "Engagement letter templating",
+        ],
+        catalog_path=ROOT / "tutorial_catalog.json",
+    )
 
     print(f"Wrote {out_path.name} — open it in Jupyter and Run All to experience the tutorial.")
 

--- a/notebooks/tutorial_catalog.json
+++ b/notebooks/tutorial_catalog.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "96e2ff771a084ee29953ac61fd35ed3d",
+    "name": "ClientEngagementLetterDraft",
+    "description": "Generate draft client engagement letters from CRM metadata, service catalogues, and reusable templates.",
+    "toolsets": [
+      {
+        "id": "6e428d2b9afa46948b183c740214ae22",
+        "tutorial": "notebooks/Client_Engagement_Letter_Draft_Tutorial.ipynb",
+        "tools": [
+          "Deltek Vantagepoint mock API integration",
+          "Practice CS mock API integration",
+          "Engagement letter templating"
+        ]
+      }
+    ]
+  }
+]

--- a/src/amplify_automations/core/tutorial_catalog.py
+++ b/src/amplify_automations/core/tutorial_catalog.py
@@ -1,0 +1,168 @@
+"""Utilities for maintaining the tutorial metadata catalogue.
+
+The catalogue stores metadata about tutorial notebooks for each automation step.
+Each step has a stable random identifier along with one or more toolset
+combinations, each of which references a tutorial notebook.  This module
+provides a single public entry point – :func:`register_tutorial` – that updates
+the catalogue and guarantees identifiers remain unique across the repository.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import MutableMapping
+from pathlib import Path
+from typing import Iterable, List, Sequence
+from uuid import uuid4
+
+
+DEFAULT_CATALOG_PATH = Path("notebooks/tutorial_catalog.json")
+
+
+def _load_catalog(path: Path) -> List[MutableMapping[str, object]]:
+    """Return the existing catalogue data.
+
+    If the file does not exist or contains invalid JSON, an empty list is
+    returned.  The function is intentionally forgiving so the register helper
+    never fails because of a missing or malformed file during local iterations.
+    """
+
+    if not path.exists():
+        return []
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return []
+
+    if isinstance(data, list):
+        # Ensure all entries are mutable dicts for downstream updates.
+        return [dict(item) for item in data if isinstance(item, MutableMapping)]
+    return []
+
+
+def _write_catalog(path: Path, data: Sequence[MutableMapping[str, object]]) -> None:
+    """Write ``data`` to ``path`` using a stable, pretty-printed format."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(list(data), indent=2, sort_keys=False)
+    path.write_text(text + "\n", encoding="utf-8")
+
+
+def _normalise_tools(tools: Iterable[str]) -> List[str]:
+    """Return ``tools`` as a list with duplicates removed, preserving order."""
+
+    seen = set()
+    normalised: List[str] = []
+    for item in tools:
+        if item not in seen:
+            normalised.append(item)
+            seen.add(item)
+    return normalised
+
+
+def _generate_unique_id(used: set[str]) -> str:
+    """Return a random hexadecimal identifier that is not present in ``used``."""
+
+    while True:
+        candidate = uuid4().hex
+        if candidate not in used:
+            used.add(candidate)
+            return candidate
+
+
+def register_tutorial(
+    *,
+    step_name: str,
+    description: str,
+    tutorial_path: str,
+    tools: Iterable[str],
+    catalog_path: str | Path | None = None,
+) -> None:
+    """Register or update metadata for a tutorial notebook.
+
+    Parameters
+    ----------
+    step_name:
+        Human readable name of the automation step (e.g. ``"TBCollector"``).
+    description:
+        Short description of the automation showcased by the notebook.
+    tutorial_path:
+        File name of the generated notebook relative to the repository root.
+    tools:
+        Iterable of tool names that comprise the documented toolset.
+    catalog_path:
+        Optional explicit path to the catalogue JSON.  When omitted the default
+        ``notebooks/tutorial_catalog.json`` file is used.
+    """
+
+    path = Path(catalog_path) if catalog_path is not None else DEFAULT_CATALOG_PATH
+    data = _load_catalog(path)
+
+    # Track used identifiers across the full catalogue so new IDs remain unique.
+    used_ids: set[str] = set()
+    for entry in data:
+        entry_id = entry.get("id")
+        if isinstance(entry_id, str):
+            used_ids.add(entry_id)
+        for toolset in entry.get("toolsets", []):
+            if isinstance(toolset, MutableMapping):
+                toolset_id = toolset.get("id")
+                if isinstance(toolset_id, str):
+                    used_ids.add(toolset_id)
+
+    # Locate or create the step entry.
+    step_entry: MutableMapping[str, object] | None = None
+    for entry in data:
+        if entry.get("name") == step_name:
+            step_entry = entry
+            break
+
+    if step_entry is None:
+        step_entry = {
+            "id": _generate_unique_id(used_ids),
+            "name": step_name,
+            "description": description,
+            "toolsets": [],
+        }
+        data.append(step_entry)
+    else:
+        # Update description to keep catalogue fresh; do not mutate ID.
+        step_entry["description"] = description
+        if "toolsets" not in step_entry or not isinstance(step_entry["toolsets"], list):
+            step_entry["toolsets"] = []
+
+    toolsets = step_entry.setdefault("toolsets", [])
+    assert isinstance(toolsets, list)  # for type checkers
+
+    normalised_tools = _normalise_tools(tools)
+    tutorial_name = str(tutorial_path)
+
+    toolset_entry: MutableMapping[str, object] | None = None
+    for item in toolsets:
+        if isinstance(item, MutableMapping) and item.get("tutorial") == tutorial_name:
+            toolset_entry = item
+            break
+
+    if toolset_entry is None:
+        toolset_entry = {
+            "id": _generate_unique_id(used_ids),
+            "tutorial": tutorial_name,
+            "tools": normalised_tools,
+        }
+        toolsets.append(toolset_entry)
+    else:
+        toolset_entry["tools"] = normalised_tools
+
+    # Sort entries for reproducible diffs.
+    data.sort(key=lambda item: str(item.get("name", "")))
+    for entry in data:
+        toolset_list = entry.get("toolsets")
+        if isinstance(toolset_list, list):
+            toolset_list.sort(key=lambda item: str(item.get("tutorial", "")))
+
+    _write_catalog(path, data)
+
+
+__all__ = ["register_tutorial", "DEFAULT_CATALOG_PATH"]
+

--- a/tests/test_tutorial_catalog.py
+++ b/tests/test_tutorial_catalog.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from amplify_automations.core.tutorial_catalog import register_tutorial
+
+
+def _load(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_register_tutorial_creates_catalog(tmp_path):
+    catalog = tmp_path / "catalog.json"
+
+    register_tutorial(
+        step_name="ExampleStep",
+        description="Example description",
+        tutorial_path="notebooks/example.ipynb",
+        tools=["Tool A", "Tool B"],
+        catalog_path=catalog,
+    )
+
+    data = _load(catalog)
+    assert len(data) == 1
+
+    entry = data[0]
+    assert entry["name"] == "ExampleStep"
+    assert entry["description"] == "Example description"
+    assert "id" in entry
+
+    toolsets = entry["toolsets"]
+    assert len(toolsets) == 1
+    toolset = toolsets[0]
+    assert toolset["tutorial"] == "notebooks/example.ipynb"
+    assert toolset["tools"] == ["Tool A", "Tool B"]
+    assert toolset["id"] != entry["id"]
+
+
+def test_register_tutorial_updates_existing_entries(tmp_path):
+    catalog = tmp_path / "catalog.json"
+
+    register_tutorial(
+        step_name="ExampleStep",
+        description="Old description",
+        tutorial_path="notebooks/example.ipynb",
+        tools=["Tool A", "Tool B"],
+        catalog_path=catalog,
+    )
+
+    original = _load(catalog)[0]
+    original_step_id = original["id"]
+    original_toolset_id = original["toolsets"][0]["id"]
+
+    register_tutorial(
+        step_name="ExampleStep",
+        description="Refreshed description",
+        tutorial_path="notebooks/example.ipynb",
+        tools=["Tool B", "Tool A", "Tool A"],
+        catalog_path=catalog,
+    )
+
+    updated = _load(catalog)[0]
+    assert updated["id"] == original_step_id
+    assert updated["description"] == "Refreshed description"
+
+    toolset = updated["toolsets"][0]
+    assert toolset["id"] == original_toolset_id
+    # Tools are de-duplicated but order respects first appearance
+    assert toolset["tools"] == ["Tool B", "Tool A"]
+
+
+def test_register_tutorial_adds_additional_toolsets(tmp_path):
+    catalog = tmp_path / "catalog.json"
+
+    register_tutorial(
+        step_name="ExampleStep",
+        description="Initial",
+        tutorial_path="notebooks/example.ipynb",
+        tools=["Tool A"],
+        catalog_path=catalog,
+    )
+
+    register_tutorial(
+        step_name="ExampleStep",
+        description="Initial",
+        tutorial_path="notebooks/example_alt.ipynb",
+        tools=["Tool B"],
+        catalog_path=catalog,
+    )
+
+    data = _load(catalog)
+    assert len(data) == 1
+
+    toolsets = data[0]["toolsets"]
+    assert len(toolsets) == 2
+
+    tutorials = [toolset["tutorial"] for toolset in toolsets]
+    assert tutorials == sorted(tutorials)
+
+    ids = {data[0]["id"]}
+    ids.update(toolset["id"] for toolset in toolsets)
+    assert len(ids) == 3  # all identifiers should be unique


### PR DESCRIPTION
## Summary
- add a tutorial catalog helper that maintains unique step and toolset identifiers
- update the Client Engagement Letter Draft notebook builder to register its tutorial metadata
- generate the initial tutorial catalog JSON and cover the helper with unit tests

## Testing
- pytest *(fails: pandas requires compiled dependencies and the package import path is unavailable without editable install)*

------
https://chatgpt.com/codex/tasks/task_b_68d5520f63d0832c994973d78fa85178