### PR TITLE
Automate tutorial catalog file naming

### DIFF
--- a/notebooks/client_engagement_letter_draft_example.py
+++ b/notebooks/client_engagement_letter_draft_example.py
@@ -355,13 +355,12 @@ def build_notebook() -> None:
             "Generate draft client engagement letters from CRM metadata, service "
             "catalogues, and reusable templates."
         ),
-        tutorial_path=f"notebooks/{out_path.name}",
+        tutorial_path=out_path.name,
         tools=[
             "Deltek Vantagepoint mock API integration",
             "Practice CS mock API integration",
             "Engagement letter templating",
         ],
-        catalog_path=ROOT / "tutorial_catalog.json",
     )
 
     print(f"Wrote {out_path.name} — open it in Jupyter and Run All to experience the tutorial.")

--- a/notebooks/fdc92fe1-f8ab-42b5-b3d0-9e0beb1b9ece.json
+++ b/notebooks/fdc92fe1-f8ab-42b5-b3d0-9e0beb1b9ece.json
@@ -6,7 +6,7 @@
     "toolsets": [
       {
         "id": "d2b6abd9-4752-4002-a02a-3209710f1195",
-        "tutorial": "notebooks/Client_Engagement_Letter_Draft_Tutorial.ipynb",
+        "tutorial": "Client_Engagement_Letter_Draft_Tutorial.ipynb",
         "tools": [
           "Deltek Vantagepoint mock API integration",
           "Practice CS mock API integration",

--- a/tests/test_tutorial_catalog.py
+++ b/tests/test_tutorial_catalog.py
@@ -35,7 +35,7 @@ def test_register_tutorial_creates_catalog(tmp_path):
     toolsets = entry["toolsets"]
     assert len(toolsets) == 1
     toolset = toolsets[0]
-    assert toolset["tutorial"] == "notebooks/example.ipynb"
+    assert toolset["tutorial"] == "example.ipynb"
     assert toolset["tools"] == ["Tool A", "Tool B"]
     assert UUID_PATTERN.match(toolset["id"]) is not None
     assert toolset["id"] != entry["id"]
@@ -59,7 +59,7 @@ def test_register_tutorial_updates_existing_entries(tmp_path):
     register_tutorial(
         step_name="ExampleStep",
         description="Refreshed description",
-        tutorial_path="notebooks/example.ipynb",
+        tutorial_path=Path("notebooks") / "example.ipynb",
         tools=["Tool B", "Tool A", "Tool A"],
         catalog_path=catalog,
     )
@@ -103,7 +103,70 @@ def test_register_tutorial_adds_additional_toolsets(tmp_path):
 
     tutorials = [toolset["tutorial"] for toolset in toolsets]
     assert tutorials == sorted(tutorials)
+    assert set(tutorials) == {"example.ipynb", "example_alt.ipynb"}
 
     ids = {data[0]["id"]}
     ids.update(toolset["id"] for toolset in toolsets)
     assert len(ids) == 3  # all identifiers should be unique
+
+
+def test_default_catalog_path_uses_step_uuid(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    register_tutorial(
+        step_name="ExampleStep",
+        description="Example description",
+        tutorial_path="notebooks/example.ipynb",
+        tools=["Tool A"],
+    )
+
+    catalog_files = list((tmp_path / "notebooks").glob("*.json"))
+    assert len(catalog_files) == 1
+
+    catalog = catalog_files[0]
+    data = _load(catalog)
+    assert Path(catalog).stem == data[0]["id"]
+    assert data[0]["toolsets"][0]["tutorial"] == "example.ipynb"
+
+
+def test_existing_catalog_is_renamed_and_normalised(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    notebooks_dir = tmp_path / "notebooks"
+    notebooks_dir.mkdir()
+    catalog = notebooks_dir / "legacy_name.json"
+    catalog.write_text(
+        json.dumps(
+            [
+                {
+                    "id": "5e1f5e2f-7207-4220-ae7a-80a528bf79cb",
+                    "name": "ExampleStep",
+                    "description": "Example description",
+                    "toolsets": [
+                        {
+                            "id": "07ab4f45-29f8-4d30-9b37-6f7cb8037b1e",
+                            "tutorial": "notebooks/example.ipynb",
+                            "tools": ["Tool A"],
+                        }
+                    ],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    register_tutorial(
+        step_name="ExampleStep",
+        description="Updated description",
+        tutorial_path="example.ipynb",
+        tools=["Tool A", "Tool B"],
+    )
+
+    catalog_files = list(notebooks_dir.glob("*.json"))
+    assert len(catalog_files) == 1
+
+    new_catalog = catalog_files[0]
+    data = _load(new_catalog)
+    assert new_catalog.stem == data[0]["id"]
+    assert data[0]["description"] == "Updated description"
+    assert data[0]["toolsets"][0]["tutorial"] == "example.ipynb"


### PR DESCRIPTION
## Summary
- ensure the tutorial catalog automatically resolves the per-step JSON file, renames it to the step UUID, and normalises stored notebook references
- update the client engagement tutorial generator to rely on the default per-step catalog file naming
- extend the tutorial catalog tests to cover default naming, renaming, and normalisation behaviour

## Testing
- PYTHONPATH=src pytest tests/test_tutorial_catalog.py

------
https://chatgpt.com/codex/tasks/task_b_68d5b024d798832ca08f472e4300caa0