### PR TITLE
Simplify tutorial tool names

### DIFF
--- a/notebooks/client_engagement_letter_draft_example.py
+++ b/notebooks/client_engagement_letter_draft_example.py
@@ -357,9 +357,9 @@ def build_notebook() -> None:
         ),
         tutorial_path=out_path.name,
         tools=[
-            "Deltek Vantagepoint mock API integration",
-            "Practice CS mock API integration",
-            "Engagement letter templating",
+            "Deltek Vantagepoint",
+            "Practice CS",
+            "Engagement letter",
         ],
     )
 

--- a/notebooks/fdc92fe1-f8ab-42b5-b3d0-9e0beb1b9ece.json
+++ b/notebooks/fdc92fe1-f8ab-42b5-b3d0-9e0beb1b9ece.json
@@ -8,9 +8,9 @@
         "id": "d2b6abd9-4752-4002-a02a-3209710f1195",
         "tutorial": "Client_Engagement_Letter_Draft_Tutorial.ipynb",
         "tools": [
-          "Deltek Vantagepoint mock API integration",
-          "Practice CS mock API integration",
-          "Engagement letter templating"
+          "Deltek Vantagepoint",
+          "Practice CS",
+          "Engagement letter"
         ]
       }
     ]

--- a/tests/test_tutorial_catalog.py
+++ b/tests/test_tutorial_catalog.py
@@ -110,6 +110,26 @@ def test_register_tutorial_adds_additional_toolsets(tmp_path):
     assert len(ids) == 3  # all identifiers should be unique
 
 
+def test_tool_names_are_simplified_to_software_titles(tmp_path):
+    catalog = tmp_path / "catalog.json"
+
+    register_tutorial(
+        step_name="ExampleStep",
+        description="Example description",
+        tutorial_path="notebooks/example.ipynb",
+        tools=[
+            "Deltek Vantagepoint mock API integration",
+            "Practice CS mock API integration",
+            "Practice CS",
+        ],
+        catalog_path=catalog,
+    )
+
+    entry = _load(catalog)[0]
+    toolset = entry["toolsets"][0]
+    assert toolset["tools"] == ["Deltek Vantagepoint", "Practice CS"]
+
+
 def test_default_catalog_path_uses_step_uuid(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 


### PR DESCRIPTION
## Summary
- ensure tutorial registration only stores simplified software names for toolsets
- update the client engagement letter assets to use the normalised tool names
- add regression coverage for descriptor stripping when registering tutorials

## Testing
- pytest *(fails: pandas binary compatibility error and missing amplify_automations import when running outside editable install)*

------
https://chatgpt.com/codex/tasks/task_b_68d5b7788358832cb6f4eb5e9e7d750c